### PR TITLE
Minor update to default DESTDIR to $$PWD in project pro file

### DIFF
--- a/qredisclient.pro
+++ b/qredisclient.pro
@@ -5,6 +5,10 @@ TARGET = qredisclient
 
 include($$PWD/qredisclient.pri)
 
+isEmpty(DESTDIR) {
+    DESTDIR = $$PWD
+}
+
 OBJECTS_DIR = $$DESTDIR/obj
 MOC_DIR = $$DESTDIR/obj
 RCC_DIR = $$DESTDIR/obj


### PR DESCRIPTION
In windows we'll get the object files under C:\obj

Just thought it would be more complete with this change