### PR TITLE
Update libssh2 to 1.8.0

### DIFF
--- a/3rdparty/3rdparty.pri
+++ b/3rdparty/3rdparty.pri
@@ -9,8 +9,8 @@ SOURCES += $$PWD/hiredis/read.c \
 
 
 unix:mac {
-    INCLUDEPATH += /usr/local/Cellar/libssh2/1.7.0/include
-    LIBS += -L/usr/local/Cellar/libssh2/1.7.0/lib
+    INCLUDEPATH += /usr/local/Cellar/libssh2/1.8.0/include
+    LIBS += -L/usr/local/Cellar/libssh2/1.8.0/lib
     
     INCLUDEPATH += /usr/local/Cellar/openssl/1.0.2j/include
     LIBS += -L/usr/local/Cellar/openssl/1.0.2j/lib


### PR DESCRIPTION
Update libssh2 to 1.8.0 for mac