### PR TITLE
Appveyor build fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,15 +3,22 @@ image: Visual Studio 2017
 init:
 - cmd: >-
     set PATH=%QTDIR%\bin;%PATH%
+
     call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 environment:
   QTDIR: C:\Qt\5.9.7\msvc2017_64
 build_script:
 - cmd: >-
     git submodule update --init --recursive
+
     cd 3rdparty\hiredis
+
     git apply ..\hiredis-win.patch
+
     cd ..\..
-    qmake
-    nmake
+
+    qmake CONFIG+=release DESTDIR=%cd%/build
+
+    nmake /S /NOLOGO
+
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+init:
+- cmd: >-
+    set PATH=%QTDIR%\bin;%PATH%
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+environment:
+  QTDIR: C:\Qt\5.9.7\msvc2017_64
+build_script:
+- cmd: >-
+    git submodule update --init --recursive
+    cd 3rdparty\hiredis
+    git apply ..\hiredis-win.patch
+    cd ..\..
+    qmake
+    nmake
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
 
     call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 environment:
-  QTDIR: C:\Qt\5.9.7\msvc2017_64
+  QTDIR: C:\Qt\5.9\msvc2017_64
 build_script:
 - cmd: >-
     git submodule update --init --recursive
@@ -17,8 +17,9 @@ build_script:
 
     cd ..\..
 
+    qmake -v
+
     qmake CONFIG+=release DESTDIR=%cd%/build
 
     nmake /S /NOLOGO
-
 


### PR DESCRIPTION
Since the Appveyor build seemed to be broken, I took the liberty to add a small appveyor.yml that contains the missing "git apply" using the already provided Windows patch.

[![Build status](https://ci.appveyor.com/api/projects/status/5ui2o7xqlfuadh1g/branch/master?svg=true)](https://ci.appveyor.com/project/kplindegaard/qredisclient/branch/master)


