### PR TITLE
Pipelining

### DIFF
--- a/src/qredisclient/command.cpp
+++ b/src/qredisclient/command.cpp
@@ -227,7 +227,7 @@ QByteArray RedisClient::Command::serializeToRESP() const
 QByteArray RedisClient::Command::serializeToPipeline() const
 {
     char separator[] = "\r\n";
-    QByteArray result;
+    QByteArray result("MULTI\r\n");
     for (QByteArray partArray : m_commandWithArguments)
         result.append(partArray).append(separator, 2);
     return result;

--- a/src/qredisclient/command.cpp
+++ b/src/qredisclient/command.cpp
@@ -33,6 +33,11 @@ RedisClient::Command &RedisClient::Command::append(const QByteArray &part)
     return *this;
 }
 
+int RedisClient::Command::length() const
+{
+    return m_commandWithArguments.length();
+}
+
 QList<QByteArray> RedisClient::Command::splitCommandString(const QString &rawCommand)
 {
     QList<QByteArray> parts;
@@ -143,7 +148,7 @@ bool RedisClient::Command::isHiPriorityCommand() const
     return m_hiPriorityCommand;
 }
 
-bool RedisClient::Command::isPipeline() const
+bool RedisClient::Command::isPipelineCommand() const
 {
     return m_isPipeline;
 }
@@ -230,5 +235,6 @@ QByteArray RedisClient::Command::serializeToPipeline() const
     QByteArray result("MULTI\r\n");
     for (QByteArray partArray : m_commandWithArguments)
         result.append(partArray).append(separator, 2);
+    result.append("EXEC\r\n");
     return result;
 }

--- a/src/qredisclient/command.h
+++ b/src/qredisclient/command.h
@@ -55,6 +55,12 @@ public:
     Command &append(const QByteArray& part);
 
     /**
+     * @brief length
+     * @return Number of command arguments
+     */
+    int length() const;
+
+    /**
      * @brief Get command in RESP or Pipeline format
      * @return QByteArray
      */
@@ -149,7 +155,7 @@ public:
     bool isSubscriptionCommand() const;
     bool isUnSubscriptionCommand() const;
     bool isAuthCommand() const;
-    bool isPipeline() const;
+    bool isPipelineCommand() const;
 
 protected:
     /**

--- a/src/qredisclient/command.h
+++ b/src/qredisclient/command.h
@@ -55,7 +55,7 @@ public:
     Command &append(const QByteArray& part);
 
     /**
-     * @brief Get command in RESP format
+     * @brief Get command in RESP or Pipeline format
      * @return QByteArray
      */
     QByteArray  getByteRepresentation() const;
@@ -129,6 +129,12 @@ public:
     bool isHiPriorityCommand() const;
 
     /**
+     * @brief Enable/disable pipeline mode. Default is off.
+     * @param enable
+     */
+    void setPipelineCommand(const bool enable);
+
+    /**
      * @brief isValid
      * @return
      */
@@ -143,6 +149,20 @@ public:
     bool isSubscriptionCommand() const;
     bool isUnSubscriptionCommand() const;
     bool isAuthCommand() const;
+    bool isPipeline() const;
+
+protected:
+    /**
+     * @brief Serialize command to RESP format
+     * @return
+     */
+    QByteArray serializeToRESP() const;
+
+    /**
+     * @brief Serialize command to Pipeline format
+     * @return
+     */
+    QByteArray serializeToPipeline() const;
 
 public:
     /**
@@ -157,6 +177,7 @@ protected:
     QList<QByteArray> m_commandWithArguments;
     int m_dbIndex;
     bool m_hiPriorityCommand;
+    bool m_isPipeline;
     Callback m_callback;
 };
 }

--- a/src/qredisclient/connection.h
+++ b/src/qredisclient/connection.h
@@ -62,9 +62,11 @@ class Connection : public QObject {
   /**
    * @brief Constructs connection class
    * @param c - connection config
+   * @param autoconnect - Auto connect if disconnected
+   * @param usePipeline - Pipeline transporter (intended only for pipeline commands)
    * NOTE: different config options are required for different transporters.
    */
-  Connection(const ConnectionConfig &c, bool autoConnect = true);
+  Connection(const ConnectionConfig &c, bool autoConnect = true, bool usePipeline = false);
 
   /**
    * @brief ~Connection
@@ -331,6 +333,7 @@ class Connection : public QObject {
   Mode m_currentMode;
   QMutex m_dbNumberMutex;
   bool m_autoConnect;
+  bool m_pipeline;
   bool m_stoppingTransporter;
   RawKeysListCallback m_wrapper;
   RedisClient::Command::Callback m_cmdCallback;

--- a/src/qredisclient/transporters/defaulttransporter.h
+++ b/src/qredisclient/transporters/defaulttransporter.h
@@ -15,10 +15,10 @@ class DefaultTransporter : public AbstractTransporter {
   Q_OBJECT
  public:
   DefaultTransporter(Connection* c);
-  ~DefaultTransporter();
+  ~DefaultTransporter() override;
 
  public slots:
-  void disconnectFromHost();
+  void disconnectFromHost() override;
 
  protected:
   bool isInitialized() const override;
@@ -36,7 +36,7 @@ class DefaultTransporter : public AbstractTransporter {
   void error(QAbstractSocket::SocketError error);
   void sslError(const QList<QSslError>& errors);
 
- private:
+ protected:
   QSharedPointer<QSslSocket> m_socket;
   QMutex m_disconnectLock;
   bool m_errorOccurred;

--- a/src/qredisclient/transporters/pipelinetransporter.cpp
+++ b/src/qredisclient/transporters/pipelinetransporter.cpp
@@ -1,0 +1,67 @@
+#include "pipelinetransporter.h"
+#include <QThread>
+
+namespace RedisClient {
+
+PipelineTransporter::PipelineTransporter(Connection* c) :
+    DefaultTransporter(c)
+{
+}
+
+PipelineTransporter::~PipelineTransporter()
+{
+}
+
+void PipelineTransporter::addCommand(const Command &cmd)
+{
+    QMutexLocker locker(&m_pipelineMutex);
+    m_pipelineCmd = cmd;
+
+    // Default behavior is it's not a pipeline command
+    if (!cmd.isPipelineCommand())
+    {
+        DefaultTransporter::addCommand(cmd);
+        return;
+    }
+
+    m_bulkLength = cmd.length();
+    QByteArray cmdBytes = cmd.getByteRepresentation();
+    sendCommand(cmdBytes);
+
+    emit commandAdded();
+}
+
+void PipelineTransporter::readyRead()
+{
+    QMutexLocker locker(&m_pipelineMutex);
+    if (m_pipelineCmd.isPipelineCommand())
+    {
+        while (m_bulkLength >= 0 && canReadFromSocket())
+        {
+            QByteArray tmp = m_socket->readLine();
+            m_bulkLength--;
+        }
+        if (m_bulkLength >= 0)
+            return;
+
+        if (canReadFromSocket())
+        {
+            QByteArray src = readFromSocket();
+            m_response.appendToSource(src);
+            if (!m_response.isValid())
+                return;
+
+            // The exec response should be OK and we can return it
+            RedisClient::Response responseToSend = m_response;
+            m_response.reset();
+
+            auto runningCmd = QSharedPointer<RedisClient::AbstractTransporter::RunningCommand>(new RedisClient::AbstractTransporter::RunningCommand(m_pipelineCmd));
+            m_runningCommands.enqueue(runningCmd);
+            sendResponse(responseToSend);
+        }
+    }
+    else
+        DefaultTransporter::readyRead();
+}
+
+};

--- a/src/qredisclient/transporters/pipelinetransporter.h
+++ b/src/qredisclient/transporters/pipelinetransporter.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "defaulttransporter.h"
+
+namespace RedisClient {
+
+/**
+ * @brief The PipelineTransporter class
+ * Provides execution of redis pipeline commands.
+ */
+class PipelineTransporter : public DefaultTransporter {
+    Q_OBJECT
+
+public:
+    PipelineTransporter(Connection* c);
+    ~PipelineTransporter() override;
+
+public slots:
+    void addCommand(const Command &) override;
+    void readyRead() override;
+
+private:
+    QMutex m_pipelineMutex;
+    Command m_pipelineCmd;
+    int m_bulkLength;
+};
+
+}  // namespace RedisClient

--- a/tests/unit_tests/test_command.cpp
+++ b/tests/unit_tests/test_command.cpp
@@ -119,5 +119,5 @@ void TestCommand::pipelineCommand()
     QCOMPARE(cmd.isUnSubscriptionCommand(), false);
 
     QByteArray actualResult = cmd.getByteRepresentation();
-    QCOMPARE(actualResult, QByteArray("PING\r\nPING\r\nPING\r\n"));
+    QCOMPARE(actualResult, QByteArray("MULTI\r\nPING\r\nPING\r\nPING\r\nEXEC\r\n"));
 }

--- a/tests/unit_tests/test_command.cpp
+++ b/tests/unit_tests/test_command.cpp
@@ -104,3 +104,20 @@ void TestCommand::scanCommandIsValid_data()
     QTest::newRow("Invalid value scan") << QList<QByteArray>{"set", "test", "0"} << false;
 }
 
+void TestCommand::pipelineCommand()
+{
+    RedisClient::Command cmd({"PING"});
+    cmd.append("PING");
+    cmd.append("PING");
+    cmd.setPipelineCommand(true);
+
+    QCOMPARE(cmd.isEmpty(), false);
+    QCOMPARE(cmd.isValid(), true);
+    QCOMPARE(cmd.isAuthCommand(), false);
+    QCOMPARE(cmd.isSelectCommand(), false);
+    QCOMPARE(cmd.isSubscriptionCommand(), false);
+    QCOMPARE(cmd.isUnSubscriptionCommand(), false);
+
+    QByteArray actualResult = cmd.getByteRepresentation();
+    QCOMPARE(actualResult, QByteArray("PING\r\nPING\r\nPING\r\n"));
+}

--- a/tests/unit_tests/test_command.h
+++ b/tests/unit_tests/test_command.h
@@ -17,5 +17,7 @@ private slots:
     void scanCommandSetCursor_data();
     void scanCommandIsValid();
     void scanCommandIsValid_data();
+
+    void pipelineCommand();
 };
 

--- a/tests/unit_tests/test_connection.cpp
+++ b/tests/unit_tests/test_connection.cpp
@@ -92,6 +92,21 @@ void TestConnection::runEmptyCommand()
     QCOMPARE(hasException, true);
 }
 
+void TestConnection::runPipelineCommandSync()
+{
+    Connection connection(config);
+    QVERIFY(connection.connect());
+
+    RedisClient::Command cmd({"SET pipelines rock"});
+    cmd.append("HSET MyHash Key1 1234");
+    cmd.append("HSET MyHash Key2 ABCDEFGH");
+    cmd.append("PING");
+    cmd.setPipelineCommand(true);
+    RedisClient::Response response = connection.commandSync(cmd);
+    QCOMPARE(response.isValid(), true);
+    QCOMPARE(response.toRawString().toUtf8(), QByteArray("+OK\r\n:1\r\n:1\r\n+PONG\r\n"));
+}
+
 void TestConnection::autoConnect()
 {
     //given

--- a/tests/unit_tests/test_connection.h
+++ b/tests/unit_tests/test_connection.h
@@ -51,6 +51,8 @@ private slots:
      * Pipeline tests
     */
     void runPipelineCommandSync();
+    void runPipelineCommandAsync();
+    void benchmarkPipeline();
 
     /*
      * Stability tests

--- a/tests/unit_tests/test_connection.h
+++ b/tests/unit_tests/test_connection.h
@@ -48,6 +48,11 @@ private slots:
     void subscribeAndUnsubscribe();
 
     /*
+     * Pipeline tests
+    */
+    void runPipelineCommandSync();
+
+    /*
      * Stability tests
      */
     void checkQueueProcessing();

--- a/tests/unit_tests/test_connection.h
+++ b/tests/unit_tests/test_connection.h
@@ -10,6 +10,9 @@ class TestConnection : public BaseTestCase
 {
     Q_OBJECT
 
+signals:
+    void callbackReceived();
+
 private slots:
     void init();
 
@@ -53,6 +56,7 @@ private slots:
     void runPipelineCommandSync();
     void runPipelineCommandAsync();
     void benchmarkPipeline();
+    void benchmarkPipelineAsync();
 
     /*
      * Stability tests


### PR DESCRIPTION
Ref issue #35 and my last comment there regarding support for pipelining, I'll take the chance to just submit the PR now. Probably easier to see what the changes are directly in the PR than interpret what I am saying and just as important not saying there.

Please have a look, @uglide , and see what you make of it. Suggestions/modifications are appreciated and of course welcome. I've tried to stay as true as I could to the original implementation and not break anything. Pipelining should be an optional extra feature, no one should have to change their code just because of this. 

Just for the record, here's a simple example taken from the unit tests:

```
void TestConnection::runPipelineCommandSync()
{
    Connection connection(config, true, true);  // 3rd param instructs pipeline transporter
    QVERIFY(connection.connect());

    RedisClient::Command cmd({"SET pipelines rock"});
    cmd.append("HSET MyHash Key1 1234");
    cmd.append("HSET MyHash Key2 ABCDEFGH");
    cmd.setPipelineCommand(true);  // Tell cmd the instructions are in a bulk op.

    RedisClient::Response response = connection.commandSync(cmd);

    QCOMPARE(response.isArray(), true);
    QCOMPARE(response.getValue().toList().length(), 3);
    QCOMPARE(response.toRawString(0).toUtf8(),
             QByteArray("*3\r\n+OK\r\n:1\r\n:1\r\n"));
}
```

I've only compiled with Qt 5.9.7. Complete set of unit tests pass on both Linux and Windows when using Redis in Docker (redis:latest).