### PR TITLE
Update command execution interface:

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "3rdparty/hiredis"]
 	path = 3rdparty/hiredis
 	url = https://github.com/redis/hiredis.git
+[submodule "3rdparty/asyncfuture"]
+	path = 3rdparty/asyncfuture
+	url = https://github.com/benlau/asyncfuture.git

--- a/3rdparty/3rdparty.pri
+++ b/3rdparty/3rdparty.pri
@@ -6,3 +6,7 @@ HEADERS += $$PWD/hiredis/read.h \
            $$PWD/hiredis/sds.h
 SOURCES += $$PWD/hiredis/read.c \
            $$PWD/hiredis/sds.c
+
+
+# Asyncfuture
+include($$PWD/asyncfuture/asyncfuture.pri)

--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ int main(int argc, char *argv[])
   RedisClient::Connection connection(config);
   
   // Run command and wait for result
-  connection.commandSync("PING"); 
+  connection.commandSync({"PING"}); 
   
   // Run command in async mode
-  connection.command("PING");
+  connection.command({"PING"});
   
   // Run command in db #2
-  connection.command("PING", 2); 
+  connection.command({"PING"}, 2); 
   
   // Run async command with callback
-  connection.command("PING", [](RedisClient::Response r) { 
+  connection.command({"PING"}, [](RedisClient::Response r) { 
     QVariant val = r.getValue(); // get value from response
     // do stuff
   });

--- a/src/qredisclient/command.h
+++ b/src/qredisclient/command.h
@@ -1,13 +1,13 @@
 #pragma once
-#include <functional>
-#include <QString>
+#include <asyncfuture.h>
 #include <QByteArray>
 #include <QList>
 #include <QObject>
+#include <QString>
+#include <functional>
+#include "response.h"
 
 namespace RedisClient {
-
-class Response;
 
 /**
  * @brief The Command class
@@ -15,10 +15,9 @@ class Response;
  * This class is part of Public API but should be used directly only for
  * advanced cases.
  */
-class Command 
-{    
-public:
-    typedef std::function<void(Response, QString)> Callback;
+class Command {
+ public:
+  typedef std::function<void(Response, QString)> Callback;
 
 public:
     /**
@@ -26,33 +25,34 @@ public:
      */
     Command();
 
-    /**
-     * @brief Constructs command with out callback
-     * @param cmd - Command parts
-     * @param db - Database index where this command should be executed
-     */
-    Command(const QList<QByteArray>& cmd, int db = -1);
+  /**
+   * @brief Constructs command with out callback
+   * @param cmd - Command parts
+   * @param db - Database index where this command should be executed
+   */
+  Command(const QList<QByteArray>& cmd, int db = -1);
 
-    /**
-     * @brief Constructs command with callback
-     * @param cmd - Command parts
-     * @param context - QObject, command will be canceled if this object destroyed
-     * @param callback - Callback for response processing
-     * @param db - Database index where this command should be executed
-     */
-    Command(const QList<QByteArray>& cmd, QObject * context, Callback callback, int db = -1);
+  /**
+   * @brief Constructs command with callback
+   * @param cmd - Command parts
+   * @param context - QObject, command will be canceled if this object destroyed
+   * @param callback - Callback for response processing
+   * @param db - Database index where this command should be executed
+   */
+  Command(const QList<QByteArray>& cmd, QObject* context, Callback callback,
+          int db = -1);
 
-    /**
-     * @brief ~Command
-     */
-    virtual ~Command();
+  /**
+   * @brief ~Command
+   */
+  virtual ~Command();
 
-    /**
-     * @brief Append additional arg/part to command ("SET 1" + "2")
-     * @param part
-     * @return Reference to current object
-     */
-    Command &append(const QByteArray& part);
+  /**
+   * @brief Append additional arg/part to command ("SET 1" + "2")
+   * @param part
+   * @return Reference to current object
+   */
+  Command& append(const QByteArray& part);
 
     /**
      * @brief length
@@ -66,73 +66,80 @@ public:
      */
     QByteArray  getByteRepresentation() const;
 
-    /**
-     * @brief Get source command as single string
-     * @return
-     */
-    QByteArray getRawString(int limit=200) const;
+  /**
+   * @brief Get source command as single string
+   * @return
+   */
+  QByteArray getRawString(int limit = 200) const;
 
-    /**
-     * @brief Get source command as list of args
-     * @return
-     */
-    QList<QByteArray> getSplitedRepresentattion() const;
+  /**
+   * @brief Get source command as list of args
+   * @return
+   */
+  QList<QByteArray> getSplitedRepresentattion() const;
 
-    /**
-     * @brief Get specific argument/part of the command
-     * @param i
-     * @return
-     */
-    QString getPartAsString(int i) const;
+  /**
+   * @brief Get specific argument/part of the command
+   * @param i
+   * @return
+   */
+  QString getPartAsString(int i) const;
 
-    /**
-     * @brief Get database index where this command should be executed
-     * @return
-     */
-    int getDbIndex() const;
+  /**
+   * @brief Get database index where this command should be executed
+   * @return
+   */
+  int getDbIndex() const;
 
-    /**
-     * @brief hasDbIndex
-     * @return
-     */
-    bool hasDbIndex() const;
+  /**
+   * @brief hasDbIndex
+   * @return
+   */
+  bool hasDbIndex() const;
 
-    /**
-     * @brief Get callback context
-     * @return
-     */
-    QObject* getOwner() const;
+  /**
+   * @brief Get callback context
+   * @return
+   */
+  QObject* getOwner() const;
 
-    /**
-     * @brief Set context and callback
-     * @param context
-     * @param callback
-     */
-    void setCallBack(QObject* context, Callback callback);
+  /**
+   * @brief Set context and callback
+   * @param context
+   * @param callback
+   */
+  void setCallBack(QObject* context, Callback callback);
 
-    /**
-     * @brief getCallBack
-     * @return
-     */
-    Callback getCallBack() const;
+  /**
+   * @brief getCallBack
+   * @return
+   */
+  Callback getCallBack() const;
 
-    /**
-     * @brief hasCallback
-     * @return
-     */
-    bool hasCallback() const;
+  /**
+   * @brief hasCallback
+   * @return
+   */
+  bool hasCallback() const;
 
-    /**
-     * @brief Mark this command as High Priority command.
-     * Command will be added to the begining of the Connection queue instead of end.
-     */
-    void markAsHiPriorityCommand();
+  /**
+   * @brief getFuture
+   * @return
+   */
+  AsyncFuture::Deferred<Response> getDeferred() const;
 
-    /**
-     * @brief isHiPriorityCommand
-     * @return
-     */
-    bool isHiPriorityCommand() const;
+  /**
+   * @brief Mark this command as High Priority command.
+   * Command will be added to the begining of the Connection queue instead of
+   * end.
+   */
+  void markAsHiPriorityCommand();
+
+  /**
+   * @brief isHiPriorityCommand
+   * @return
+   */
+  bool isHiPriorityCommand() const;
 
     /**
      * @brief Enable/disable pipeline mode. Default is off.
@@ -170,13 +177,13 @@ protected:
      */
     QByteArray serializeToPipeline() const;
 
-public:
-    /**
-     * @brief Parse command from raw string.
-     * Useful for CLI clients.
-     * @return Command parts as list.
-     */
-    static QList<QByteArray> splitCommandString(const QString &);
+ public:
+  /**
+   * @brief Parse command from raw string.
+   * Useful for CLI clients.
+   * @return Command parts as list.
+   */
+  static QList<QByteArray> splitCommandString(const QString&);
 
 protected:
     QObject * m_owner;
@@ -185,5 +192,6 @@ protected:
     bool m_hiPriorityCommand;
     bool m_isPipeline;
     Callback m_callback;
+    AsyncFuture::Deferred<Response> m_deferred;
 };
-}
+}  // namespace RedisClient

--- a/src/qredisclient/connection.h
+++ b/src/qredisclient/connection.h
@@ -18,7 +18,6 @@
 namespace RedisClient {
 
 class AbstractTransporter;
-class CommandExecutor;
 
 typedef QMap<int, int> DatabaseList;
 
@@ -194,14 +193,14 @@ class Connection : public QObject {
    * @brief command
    * @param cmd
    */
-  void command(const Command &cmd);
+  QFuture<Response> command(const Command &cmd);
 
   /**
    * @brief Execute command without callback in async mode.
    * @param rawCmd
    * @param db
    */
-  void command(QList<QByteArray> rawCmd, int db = -1);
+  QFuture<Response> command(QList<QByteArray> rawCmd, int db = -1);
 
   /**
    * @brief Execute command with callback in async mode.
@@ -210,8 +209,9 @@ class Connection : public QObject {
    * @param callback
    * @param db
    */
-  void command(QList<QByteArray> rawCmd, QObject *owner,
-               RedisClient::Command::Callback callback, int db = -1);
+  QFuture<Response> command(QList<QByteArray> rawCmd, QObject *owner,
+                            RedisClient::Command::Callback callback,
+                            int db = -1);
 
   /**
    * @brief Hi-level wrapper with basic error handling
@@ -254,15 +254,6 @@ class Connection : public QObject {
    */
   Response commandSync(QList<QByteArray> rawCmd, int db = -1);
 
-  /*
-   * Aliases for ^ function
-   */
-  Response commandSync(QString cmd, int db = -1);
-  Response commandSync(QString cmd, QString arg1, int db = -1);
-  Response commandSync(QString cmd, QString arg1, QString arg2, int db = -1);
-  Response commandSync(QString cmd, QString arg1, QString arg2, QString arg3,
-                       int db = -1);
-
   /**
    * @brief CollectionCallback
    */
@@ -291,10 +282,11 @@ class Connection : public QObject {
       const ScanCommand &cmd, IncrementalCollectionCallback callback);
 
   /**
-   * @brief runCommand - Low level commands execution API
+   * @brief runCommand
    * @param cmd
+   * @return QFuture<Response>
    */
-  virtual void runCommand(const Command &cmd);
+  virtual QFuture<Response> runCommand(const Command &cmd);
 
   /**
    * @brief waitForIdle - Wait until all commands in queue will be processed

--- a/src/qredisclient/transporters/abstracttransporter.h
+++ b/src/qredisclient/transporters/abstracttransporter.h
@@ -34,7 +34,7 @@ class AbstractTransporter : public QObject {
 
  public slots:
   virtual void init();
-  virtual void disconnectFromHost() {}
+  virtual void disconnectFromHost();
   virtual void addCommand(const Command&);
   virtual void cancelCommands(QObject*);
   virtual void readyRead();

--- a/src/qredisclient/transporters/defaulttransporter.cpp
+++ b/src/qredisclient/transporters/defaulttransporter.cpp
@@ -40,9 +40,9 @@ void RedisClient::DefaultTransporter::initSocket() {
 void RedisClient::DefaultTransporter::disconnectFromHost() {
   QMutexLocker lock(&m_disconnectLock);
 
-  if (m_socket.isNull()) return;
+  RedisClient::AbstractTransporter::disconnectFromHost();
 
-  m_loopTimer->stop();
+  if (m_socket.isNull()) return;
 
   m_socket->abort();
   m_socket.clear();

--- a/src/qredisclient/utils/sync.cpp
+++ b/src/qredisclient/utils/sync.cpp
@@ -2,71 +2,33 @@
 #include "qredisclient/command.h"
 
 RedisClient::SignalWaiter::SignalWaiter(uint timeout)
-    : m_result(false), m_resultReceived(false)
-{
-    m_timeoutTimer.setSingleShot(true);
-    m_timeoutTimer.setInterval(timeout);
+    : m_result(false), m_resultReceived(false) {
+  m_timeoutTimer.setSingleShot(true);
+  m_timeoutTimer.setInterval(timeout);
 
-    connect(&m_timeoutTimer, SIGNAL(timeout()), &m_loop, SLOT(quit()));
+  connect(&m_timeoutTimer, SIGNAL(timeout()), &m_loop, SLOT(quit()));
 }
 
-bool RedisClient::SignalWaiter::wait()
-{
-    if (m_resultReceived) { // result recieved before wait() call
-        return m_result;
-    }
-
-    m_timeoutTimer.start();
-    m_loop.exec();
+bool RedisClient::SignalWaiter::wait() {
+  if (m_resultReceived) {  // result recieved before wait() call
     return m_result;
+  }
+
+  m_timeoutTimer.start();
+  m_loop.exec();
+  return m_result;
 }
 
-void RedisClient::SignalWaiter::abort()
-{
-    m_result=false;
-    m_resultReceived = true;
-    m_loop.quit();
-    emit aborted();
+void RedisClient::SignalWaiter::abort() {
+  m_result = false;
+  m_resultReceived = true;
+  m_loop.quit();
+  emit aborted();
 }
 
-void RedisClient::SignalWaiter::success()
-{
-    m_result=true;
-    m_resultReceived = true;
-    m_loop.quit();
-    emit succeed();
-}
-
-RedisClient::CommandExecutor::CommandExecutor(RedisClient::Command &cmd, uint timeout)
-    : RedisClient::SignalWaiter(timeout)
-{
-    cmd.setCallBack(this, [this](Response r, QString error) {
-        if (error.isEmpty()) {
-            m_result = r;
-        } else {
-            m_error = error;
-        }
-        m_resultReceived = true;
-
-        if (m_loop.isRunning()) {
-            m_loop.exit();
-        }
-    });
-}
-
-RedisClient::Response RedisClient::CommandExecutor::waitResult()
-{
-    if (m_resultReceived) { // result recieved before wait() call
-        return m_result;
-    }
-
-    m_timeoutTimer.start();
-    m_loop.exec();
-
-    if (!m_error.isEmpty())
-        throw Exception(m_error);
-    else if (m_result.isEmpty())
-        throw Exception(tr("Command execution timeout"));
-
-    return m_result;
+void RedisClient::SignalWaiter::success() {
+  m_result = true;
+  m_resultReceived = true;
+  m_loop.quit();
+  emit succeed();
 }

--- a/src/qredisclient/utils/sync.h
+++ b/src/qredisclient/utils/sync.h
@@ -1,8 +1,9 @@
 #pragma once
-#include <QObject>
 #include <QEventLoop>
+#include <QObject>
 #include <QTimer>
 
+#include <asyncfuture.h>
 #include <qredisclient/response.h>
 
 /**
@@ -12,55 +13,42 @@ namespace RedisClient {
 
 class Command;
 
-class SignalWaiter : public QObject
-{
-    Q_OBJECT
-public:
-    SignalWaiter(uint timeout);
+class SignalWaiter : public QObject {
+  Q_OBJECT
+ public:
+  SignalWaiter(uint timeout);
 
-    bool wait();
+  bool wait();
 
-    template <typename Func1>
-    void addAbortSignal(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal)
-    {
-        connect(sender, signal, this, &SignalWaiter::abort);
-    }
+  template <typename Func1>
+  void addAbortSignal(
+      const typename QtPrivate::FunctionPointer<Func1>::Object *sender,
+      Func1 signal) {
+    connect(sender, signal, this, &SignalWaiter::abort);
+  }
 
-    template <typename Func1>
-    void addSuccessSignal(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal)
-    {
-        connect(sender, signal, this, &SignalWaiter::success);
-    }
+  template <typename Func1>
+  void addSuccessSignal(
+      const typename QtPrivate::FunctionPointer<Func1>::Object *sender,
+      Func1 signal) {
+    connect(sender, signal, this, &SignalWaiter::success);
+  }
 
-signals:
-    void succeed();
-    void aborted();
+ signals:
+  void succeed();
+  void aborted();
 
-protected slots:
-    void abort();
-    void success();
-protected:
-    QEventLoop m_loop;
-    QTimer m_timeoutTimer;   
-    bool m_resultReceived;
-private:
-    bool m_result;
+ protected slots:
+  void abort();
+  void success();
+
+ protected:
+  QEventLoop m_loop;
+  QTimer m_timeoutTimer;
+  bool m_resultReceived;
+
+ private:
+  bool m_result;
 };
 
-class CommandExecutor : public SignalWaiter
-{
-    Q_OBJECT
-    ADD_EXCEPTION
-public:
-    CommandExecutor(Command& cmd, uint timeout);
-
-    Response waitResult();
-
-private:
-    bool wait() { return false; }
-private:
-    Response m_result;
-    QString m_error;
-};
-
-}
+}  // namespace RedisClient

--- a/tests/unit_tests/mocks/dummyconnection.h
+++ b/tests/unit_tests/mocks/dummyconnection.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <asyncfuture.h>
 #include <QVariant>
 #include <functional>
 #include "qredisclient/connection.h"
@@ -53,13 +54,15 @@ class DummyConnection : public RedisClient::Connection {
     callback(resp, QString());
   }
 
-  void runCommand(const RedisClient::Command& cmd) override {
+  QFuture<RedisClient::Response> runCommand(
+      const RedisClient::Command& cmd) override {
     RedisClient::Response resp;
+    AsyncFuture::Deferred<RedisClient::Response> d;
 
     if (returnErrorOnCmdRun) {
       auto callback = cmd.getCallBack();
       callback(resp, QString("fake error"));
-      return;
+      return d.future();
     }
 
     if (fakeResponses.size()) {
@@ -74,6 +77,7 @@ class DummyConnection : public RedisClient::Connection {
 
     runCommandCalled++;
     executedCommands.push_back(cmd);
+    return d.future();
   }
 
   uint runCommandCalled;

--- a/tests/unit_tests/test_connection.cpp
+++ b/tests/unit_tests/test_connection.cpp
@@ -23,7 +23,7 @@ void TestConnection::connectToHostAndRunCommand() {
   // when
   // sync execution
   connection.connect();
-  Response actualResult = connection.commandSync("PING");
+  Response actualResult = connection.commandSync({"PING"});
 
   // then
   QCOMPARE(connection.isConnected(), true);
@@ -36,7 +36,7 @@ void TestConnection::testScanCommand() {
 
   // when
   connection.connect();
-  Response result = connection.commandSync("SCAN", "0");
+  Response result = connection.commandSync({"SCAN", "0"});
   QVariant value = result.value();
 
   // then
@@ -52,8 +52,8 @@ void TestConnection::testRetriveCollection() {
 
   // when
   connection.connect();
-  connection.commandSync("FLUSHDB");
-  connection.commandSync("SET", "test", "1");
+  connection.commandSync({"FLUSHDB"});
+  connection.commandSync({"SET", "test", "1"});
 
   connection.retrieveCollection(
       cmd, [&callbackCalled](QVariant result, QString) {
@@ -135,7 +135,7 @@ void TestConnection::runPipelineCommandAsync() {
 void TestConnection::benchmarkPipeline() {
   Connection connection(config, true);
   QVERIFY(connection.connect());
-  connection.commandSync("flushdb");
+  connection.commandSync({"flushdb"});
 
   RedisClient::Command cmd;
   cmd.setPipelineCommand(true);
@@ -160,14 +160,14 @@ void TestConnection::benchmarkPipeline() {
 
   // Read back the N'th value
   RedisClient::Response valResponse =
-      connection.commandSync("hget", "h", QString("k%1").arg(N));
+      connection.commandSync({"hget", "h", QString("k%1").arg(N).toLatin1()});
   QCOMPARE(valResponse.value(), QVariant(N));
 }
 
 void TestConnection::benchmarkPipelineAsync() {
   Connection connection(config, true);
   QVERIFY(connection.connect());
-  connection.commandSync("flushdb");
+  connection.commandSync({"flushdb"});
 
   RedisClient::Command cmd;
   cmd.setPipelineCommand(true);
@@ -200,7 +200,7 @@ void TestConnection::benchmarkPipelineAsync() {
 
   // Read back the N'th value
   RedisClient::Response valResponse =
-      connection.commandSync("hget", "ha", QString("k%1").arg(N));
+      connection.commandSync({"hget", "ha", QString("k%1").arg(N).toLatin1()});
   QCOMPARE(valResponse.value(), QVariant(N));
 }
 
@@ -211,7 +211,7 @@ void TestConnection::autoConnect() {
   // when
   bool hasException = false;
   try {
-    connection.commandSync("PING");  // valid
+    connection.commandSync({"PING"});  // valid
   } catch (Connection::Exception&) {
     hasException = true;
   }
@@ -252,9 +252,9 @@ void TestConnection::subscribeAndUnsubscribe() {
                        qDebug() << "recieved msg:" << r.value().toList();
                        messagesRecieved++;
                      });
-  connectionPublisher.commandSync("PUBLISH", "ch1", "MSG1");
-  connectionPublisher.commandSync("PUBLISH", "ch2", "MSG2");
-  connectionPublisher.commandSync("PUBLISH", "ch3", "MSG3");
+  connectionPublisher.commandSync({"PUBLISH", "ch1", "MSG1"});
+  connectionPublisher.commandSync({"PUBLISH", "ch2", "MSG2"});
+  connectionPublisher.commandSync({"PUBLISH", "ch3", "MSG3"});
 
   wait(5000);
 
@@ -276,7 +276,7 @@ void TestConnection::checkTimeout() {
     wait(1000 * 10);
   }
 
-  Response actualCommandResult = connection.commandSync("ping");
+  Response actualCommandResult = connection.commandSync({"ping"});
 
   // then
   QCOMPARE(actualCommandResult.value().toString(), QString("PONG"));
@@ -288,7 +288,7 @@ void TestConnection::checkQueueProcessing() {
 
   // when
   QVERIFY(connection.connect());
-  connection.commandSync("SET", "test_incr_key", "0");
+  connection.commandSync({"SET", "test_incr_key", "0"});
 
   for (int i = 0; i < 1000; ++i) {
     connection.command({"INCR", "test_incr_key"});
@@ -296,7 +296,7 @@ void TestConnection::checkQueueProcessing() {
 
   // then
   QCOMPARE(connection.waitForIdle(10000), true);
-  QCOMPARE(connection.commandSync("GET", "test_incr_key").value(),
+  QCOMPARE(connection.commandSync({"GET", "test_incr_key"}).value(),
            QVariant(1000));
 }
 
@@ -306,12 +306,11 @@ void TestConnection::connectWithAuth() {
 
   // when
   connection.connect();
-  connection.commandSync(
-      QList<QByteArray>{"config", "set", "requirepass", "test"});
+  connection.commandSync({"config", "set", "requirepass", "test"});
   connection.disconnect();
 
   bool actualConnectResult = connection.connect();
-  Response actualCommandResult = connection.commandSync("ping");
+  Response actualCommandResult = connection.commandSync({"ping"});
 
   // then
   QCOMPARE(actualConnectResult, true);
@@ -372,7 +371,7 @@ void TestConnection::testWithDummyTransporter() {
 
   // when
   QVERIFY(connection->connect());
-  Response actualResult = connection->commandSync("PING");
+  Response actualResult = connection->commandSync({"PING"});
 
   // then
   QCOMPARE(connection->isConnected(), true);


### PR DESCRIPTION
- Return QFuture<Response> instead of void
- Remove error prone command execution methods
- Remove CommandExecutor (replace with QFuture waiting)