### PR TITLE
Pipeline in proper RESP format

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ int main(int argc, char *argv[])
     // do stuff
   });
 
-  // See more usage examples in examples folder
+  // Use addToPipeline() to enable MULTI+EXEC transactions
+  RedisClient::Command cmd;
+  cmd.addToPipeline({"SET", "foo", "bar"});
+  cmd.addToPipeline({"HSET" "foz", "key", "value"});
+  RedisClient::Response response = connection.commandSync(cmd);
+
+  // See more usage examples in the tests/unit_tests folder
 }
 
 ```

--- a/src/qredisclient/command.cpp
+++ b/src/qredisclient/command.cpp
@@ -33,10 +33,14 @@ RedisClient::Command &RedisClient::Command::append(const QByteArray &part) {
   return *this;
 }
 
-RedisClient::Command &RedisClient::Command::appendToPipeline(const QList<QByteArray> cmd) {
-  if (m_isPipeline) {
-    m_pipelineCommands.append(cmd);
+RedisClient::Command &RedisClient::Command::addToPipeline(const QList<QByteArray> cmd) {
+  if(!m_isPipeline) {
+    // Convert and use existing command arguments if there any
+    if (!isEmpty())
+      m_pipelineCommands.append(m_commandWithArguments);
+    m_isPipeline = true;
   }
+  m_pipelineCommands.append(cmd);
   return *this;
 }
 

--- a/src/qredisclient/command.h
+++ b/src/qredisclient/command.h
@@ -55,11 +55,11 @@ public:
   Command& append(const QByteArray& part);
 
   /**
-   * @brief Append a new command to pipeline
+   * @brief Add a new command to pipeline
    * @param List of arguments
    * @return Reference to current object
    */
-  Command& appendToPipeline(const QList<QByteArray> cmd);
+  Command& addToPipeline(const QList<QByteArray> cmd);
 
     /**
      * @brief length

--- a/src/qredisclient/command.h
+++ b/src/qredisclient/command.h
@@ -54,6 +54,13 @@ public:
    */
   Command& append(const QByteArray& part);
 
+  /**
+   * @brief Append a new command to pipeline
+   * @param List of arguments
+   * @return Reference to current object
+   */
+  Command& appendToPipeline(const QList<QByteArray> cmd);
+
     /**
      * @brief length
      * @return Number of command arguments
@@ -169,15 +176,9 @@ protected:
      * @brief Serialize command to RESP format
      * @return
      */
-    QByteArray serializeToRESP() const;
+    QByteArray serializeToRESP(QList<QByteArray> args) const;
 
-    /**
-     * @brief Serialize command to Pipeline format
-     * @return
-     */
-    QByteArray serializeToPipeline() const;
-
- public:
+public:
   /**
    * @brief Parse command from raw string.
    * Useful for CLI clients.
@@ -188,6 +189,7 @@ protected:
 protected:
     QObject * m_owner;
     QList<QByteArray> m_commandWithArguments;
+    QList<QList<QByteArray>> m_pipelineCommands;
     int m_dbIndex;
     bool m_hiPriorityCommand;
     bool m_isPipeline;

--- a/tests/unit_tests/test_command.cpp
+++ b/tests/unit_tests/test_command.cpp
@@ -106,10 +106,11 @@ void TestCommand::scanCommandIsValid_data()
 
 void TestCommand::pipelineCommand()
 {
-    RedisClient::Command cmd({"PING"});
-    cmd.append("PING");
-    cmd.append("PING");
+    RedisClient::Command cmd;
     cmd.setPipelineCommand(true);
+    cmd.appendToPipeline({"PING"});
+    cmd.appendToPipeline({"SET", "foo"});
+    cmd.append("bar");  // Append part to previous command
 
     QCOMPARE(cmd.isEmpty(), false);
     QCOMPARE(cmd.isValid(), true);
@@ -119,5 +120,5 @@ void TestCommand::pipelineCommand()
     QCOMPARE(cmd.isUnSubscriptionCommand(), false);
 
     QByteArray actualResult = cmd.getByteRepresentation();
-    QCOMPARE(actualResult, QByteArray("MULTI\r\nPING\r\nPING\r\nPING\r\nEXEC\r\n"));
+    QCOMPARE(actualResult, QByteArray("*1\r\n$5\r\nMULTI\r\n*1\r\n$4\r\nPING\r\n*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\nbar\r\n*1\r\n$4\r\nEXEC\r\n"));
 }

--- a/tests/unit_tests/test_command.cpp
+++ b/tests/unit_tests/test_command.cpp
@@ -107,9 +107,8 @@ void TestCommand::scanCommandIsValid_data()
 void TestCommand::pipelineCommand()
 {
     RedisClient::Command cmd;
-    cmd.setPipelineCommand(true);
-    cmd.appendToPipeline({"PING"});
-    cmd.appendToPipeline({"SET", "foo"});
+    cmd.addToPipeline({"PING"});
+    cmd.addToPipeline({"SET", "foo"});
     cmd.append("bar");  // Append part to previous command
 
     QCOMPARE(cmd.isEmpty(), false);

--- a/tests/unit_tests/test_connection.cpp
+++ b/tests/unit_tests/test_connection.cpp
@@ -92,10 +92,9 @@ void TestConnection::runPipelineCommandSync() {
   QVERIFY(connection.connect());
 
   RedisClient::Command cmd;
-  cmd.setPipelineCommand(true);
-  cmd.appendToPipeline({"SET", "pipelines", "rock"});
-  cmd.appendToPipeline({"HSET", "MyHash", "Key1", "1234"});
-  cmd.appendToPipeline({"HSET", "MyHash", "Key2", "ABCDEFGH"});
+  cmd.addToPipeline({"SET", "pipelines", "rock"});
+  cmd.addToPipeline({"HSET", "MyHash", "Key1", "1234"});
+  cmd.addToPipeline({"HSET", "MyHash", "Key2", "ABCDEFGH"});
   RedisClient::Response response = connection.commandSync(cmd);
 
   QCOMPARE(response.isArray(), true);
@@ -108,11 +107,9 @@ void TestConnection::runPipelineCommandAsync() {
   Connection connection(config, true);
   QVERIFY(connection.connect());
 
-  RedisClient::Command cmd;
-  cmd.setPipelineCommand(true);
-  cmd.appendToPipeline({"SET", "pipelines", "async"});
-  cmd.appendToPipeline({"HSET", "MyHashAsync", "Key1", "1234"});
-  cmd.appendToPipeline({"HSET", "MyHashAsync", "Key2", "ABCDEFGH"});
+  RedisClient::Command cmd({"SET", "pipelines", "async"});
+  cmd.addToPipeline({"HSET", "MyHashAsync", "Key1", "1234"});
+  cmd.addToPipeline({"HSET", "MyHashAsync", "Key2", "ABCDEFGH"});
 
   // Setup callback
   RedisClient::Response response;
@@ -139,10 +136,9 @@ void TestConnection::runBinaryPipelineCommand() {
   QVERIFY(connection.connect());
 
   RedisClient::Command cmd;
-  cmd.setPipelineCommand(true);
-  cmd.appendToPipeline({"SET", "crlf"});
+  cmd.addToPipeline({"SET", "crlf"});
   cmd.append("\r\n");
-  cmd.appendToPipeline({"SET", "binary"});
+  cmd.addToPipeline({"SET", "binary"});
   QByteArray arr;
   for (char k=31; k>=0; k--)
     arr.append(k);
@@ -170,11 +166,10 @@ void TestConnection::benchmarkPipeline() {
   connection.commandSync({"flushdb"});
 
   RedisClient::Command cmd;
-  cmd.setPipelineCommand(true);
   int N = 10000;
   for (int k = 1; k <= N; k++)
   {
-    cmd.appendToPipeline({"hset", "h"});
+    cmd.addToPipeline({"hset", "h"});
     cmd.append(QString("k%1").arg(k).toUtf8());
     cmd.append(QString("%1").arg(k).toUtf8());
   }
@@ -206,11 +201,10 @@ void TestConnection::benchmarkPipelineAsync() {
   connection.commandSync({"flushdb"});
 
   RedisClient::Command cmd;
-  cmd.setPipelineCommand(true);
   int N = 10000;
   for (int k = 1; k <= N; k++)
   {
-    cmd.appendToPipeline({"hset", "ha"});
+    cmd.addToPipeline({"hset", "ha"});
     cmd.append(QString("k%1").arg(k).toUtf8());
     cmd.append(QString("%1").arg(k).toUtf8());
   }

--- a/tests/unit_tests/test_connection.cpp
+++ b/tests/unit_tests/test_connection.cpp
@@ -91,10 +91,11 @@ void TestConnection::runPipelineCommandSync() {
   Connection connection(config, true);
   QVERIFY(connection.connect());
 
-  RedisClient::Command cmd({"SET pipelines rock"});
-  cmd.append("HSET MyHash Key1 1234");
-  cmd.append("HSET MyHash Key2 ABCDEFGH");
+  RedisClient::Command cmd;
   cmd.setPipelineCommand(true);
+  cmd.appendToPipeline({"SET", "pipelines", "rock"});
+  cmd.appendToPipeline({"HSET", "MyHash", "Key1", "1234"});
+  cmd.appendToPipeline({"HSET", "MyHash", "Key2", "ABCDEFGH"});
   RedisClient::Response response = connection.commandSync(cmd);
 
   QCOMPARE(response.isArray(), true);
@@ -107,10 +108,11 @@ void TestConnection::runPipelineCommandAsync() {
   Connection connection(config, true);
   QVERIFY(connection.connect());
 
-  RedisClient::Command cmd({"SET pipelines async"});
-  cmd.append("HSET MyHashAsync Key1 1234");
-  cmd.append("HSET MyHashAsync Key2 ABCDEFGH");
+  RedisClient::Command cmd;
   cmd.setPipelineCommand(true);
+  cmd.appendToPipeline({"SET", "pipelines", "async"});
+  cmd.appendToPipeline({"HSET", "MyHashAsync", "Key1", "1234"});
+  cmd.appendToPipeline({"HSET", "MyHashAsync", "Key2", "ABCDEFGH"});
 
   // Setup callback
   RedisClient::Response response;
@@ -141,7 +143,11 @@ void TestConnection::benchmarkPipeline() {
   cmd.setPipelineCommand(true);
   int N = 10000;
   for (int k = 1; k <= N; k++)
-    cmd.append(QString("hset h k%1 %1").arg(k).toUtf8());
+  {
+    cmd.appendToPipeline({"hset", "h"});
+    cmd.append(QString("k%1").arg(k).toUtf8());
+    cmd.append(QString("%1").arg(k).toUtf8());
+  }
 
   // Measure the time it takes to complete the transaction:
   QTime t0;
@@ -173,7 +179,11 @@ void TestConnection::benchmarkPipelineAsync() {
   cmd.setPipelineCommand(true);
   int N = 10000;
   for (int k = 1; k <= N; k++)
-    cmd.append(QString("hset ha k%1 %1").arg(k).toUtf8());
+  {
+    cmd.appendToPipeline({"hset", "ha"});
+    cmd.append(QString("k%1").arg(k).toUtf8());
+    cmd.append(QString("%1").arg(k).toUtf8());
+  }
 
   // Setup callback
   int tf;

--- a/tests/unit_tests/test_connection.h
+++ b/tests/unit_tests/test_connection.h
@@ -54,6 +54,7 @@ class TestConnection : public BaseTestCase {
    */
   void runPipelineCommandSync();
   void runPipelineCommandAsync();
+  void runBinaryPipelineCommand();
   void benchmarkPipeline();
   void benchmarkPipelineAsync();
 


### PR DESCRIPTION
I wasn't too happy with the existing format pipelines use. Simply put, it wasn't proper RESP protocol, so binary payloads like e.g. protobuf serialized objects would most likely not work.

To implement RESP for pipelines, I unfortunately had to expand the Command class with an additional list-of-list-of-bytearray property. Not the nicest way to do it, but deriving a pipeline command from Command and using virtual methods didn't work because its vtable reverts to Command's when the connection emits the command by reference to the transporter.

Anyway. Here it is with the following "features":
* `Command::addToPipeline()` adds a new "row" to the pipeline and switches the command object over to become a pipeline command if it wasn't that already.
* Updated unit tests. [They run just fine](https://ci.appveyor.com/project/kplindegaard/qredisclient/builds/25470524).
* Edited README.md to include a pipeline example.